### PR TITLE
Take path to general input file in params.txt

### DIFF
--- a/RunSpinDepArray.m
+++ b/RunSpinDepArray.m
@@ -83,7 +83,7 @@ for indproc=1:nproc %
     
     % prepare OAR script to run TolErrorSetEvaluatorOARrunner
     % put here the matlab version you are using
-    script=[' /sware/com/matlab_2015b ' fullfile(pwd,spfn) '\n']; 
+    script=[' ' matlabroot ' ' fullfile(pwd,'inputGeneralfile.mat') ' ' fullfile(pwd,spfn) '\n'];
     
     %fopen(fullfile(workdir,'params.txt'),'w+')
     fprintf(pfile,script');

--- a/SPINDepOARrunner.m
+++ b/SPINDepOARrunner.m
@@ -1,10 +1,10 @@
-function SPINDepOARrunner(inputdatafile)
+function SPINDepOARrunner(generalinputfile, specinputfile)
 %   SPINDepOARrunner(inputdatafile)
 %   Detailed explanation goes here
 
-load('inputGeneralfile.mat','fastring','OAM','nusp','freq','Coord','Spin','kickampl','nturns');
+load(generalinputfile,'fastring','OAM','nusp','freq','Coord','Spin','kickampl','nturns');
 
-load(inputdatafile, 'partindex','outfilename');
+load(specinputfile, 'partindex','outfilename');
 Coord_temp=Coord(:,partindex);
 Spin_temp=Spin(:,partindex);
 for indnukick=1:length(freq)


### PR DESCRIPTION
We are working with this application at Diamond. Explicitly stating the general input file path makes it easier to run on our cluster where the working directory may not be the datafile directory.